### PR TITLE
Fix joint limit check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Eclipse files
+.autotools
+.cproject
+.project

--- a/src/steered_wheel_base_controller.cpp
+++ b/src/steered_wheel_base_controller.cpp
@@ -225,8 +225,7 @@ public:
   virtual void init() = 0;
   virtual void stop() = 0;
 
-  bool isValidPos(const double pos) const
-    {return pos >= lower_limit_ && pos <= upper_limit_;}
+  bool isValidPos(const double pos);
   double getPos() const {return handle_.getPosition();}
   virtual void setPos(const double pos, const Duration& period) {}
 
@@ -238,6 +237,7 @@ protected:
 
   JointHandle handle_;
   const double lower_limit_, upper_limit_;  // Unit: radian
+  bool check_joint_limit_;
 };
 
 // Position-controlled joint
@@ -329,9 +329,17 @@ private:
 Joint::Joint(const JointHandle& handle,
              const shared_ptr<const urdf::Joint> urdf_joint) :
   handle_(handle), lower_limit_(urdf_joint->limits->lower),
-  upper_limit_(urdf_joint->limits->upper)
+  upper_limit_(urdf_joint->limits->upper), check_joint_limit_(true)
 {
   // Do nothing.
+}
+
+bool Joint::isValidPos(const double pos)
+{
+  if(!check_joint_limit_)
+    return true;
+
+  return pos >= lower_limit_ && pos <= upper_limit_;
 }
 
 // Initialize this joint.
@@ -413,9 +421,11 @@ void PIDJoint::setPos(const double pos, const Duration& period)
       angles::shortest_angular_distance_with_limits(curr_pos, pos,
                                                     lower_limit_, upper_limit_,
                                                     error);
+      check_joint_limit_ = true;
       break;
     case urdf::Joint::CONTINUOUS:
       error = angles::shortest_angular_distance(curr_pos, pos);
+      check_joint_limit_ = false;
       break;
     default:
       error = pos - curr_pos;


### PR DESCRIPTION
We tried to get your plugin running for our robot in simulation and encounter the following problem:

Our wheels are defined as "continuous" in the URDF model and no upper and lower limit are set. But when your plugin tries to get the upper and lower joint limits and can not find them, they are set to 0 by default.

Thus, the robot does not move, since the linear velocity is always set to zero, because isValidPos(...) always returns "false".

This pull request fixes this problem.